### PR TITLE
fix: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     ],
     "dependencies": {
         "@coral-xyz/anchor": "0.30.1",
-        "@elizaos/plugin-tee": "workspace:*",
-        "@elizaos/plugin-trustdb": "workspace:*",
+        "@elizaos-plugins/plugin-tee": "workspace:*",
+        "@elizaos/plugin-trustdb": "0.25.6-alpha.1",
         "@solana/spl-token": "0.4.9",
         "@solana/web3.js": "npm:@solana/web3.js@1.95.8",
         "bignumber.js": "9.1.2",
@@ -31,7 +31,8 @@
         "pumpdotfun-sdk": "1.3.2",
         "solana-agent-kit": "^1.4.0",
         "tsup": "8.3.5",
-        "vitest": "2.1.9"
+        "vitest": "2.1.9",
+        "uuid": "11.1.0"
     },
     "devDependencies": {
         "@biomejs/biome": "1.5.3",
@@ -97,5 +98,6 @@
                 "description": "Birdeye API key is required"
             }
         }
-    }
+    },
+    "packageManager": "pnpm@10.4.0+sha1.896bdea7e92d0a37e53829d6ec47871e5c750419"
 }

--- a/src/keypairUtils.ts
+++ b/src/keypairUtils.ts
@@ -1,5 +1,5 @@
 import { Keypair, PublicKey } from "@solana/web3.js";
-import { DeriveKeyProvider, TEEMode } from "@elizaos/plugin-tee";
+import { DeriveKeyProvider, TEEMode } from "@elizaos-plugins/plugin-tee";
 import bs58 from "bs58";
 import { type IAgentRuntime, elizaLogger } from "@elizaos/core";
 


### PR DESCRIPTION
Updates dependency name from `@elizaos/plugin-tee` to `@elizaos-plugins/plugin-tee` in **package.json** and **keypairUtils.ts** and adds `uuid` as a dependency as it's used in **providers/trustScoreProvider.ts**

This also updates the `@elizaos/plugin-trustdb version` as it's been removed from the original monorepo's workspace.

See issue [4](https://github.com/elizaos-plugins/plugin-solana/issues/4) for additional context.